### PR TITLE
Move load_dotenv() to root `__init__.py`.

### DIFF
--- a/01OS/01OS/__init__.py
+++ b/01OS/01OS/__init__.py
@@ -1,0 +1,3 @@
+from dotenv import load_dotenv
+
+load_dotenv()

--- a/01OS/01OS/clients/base_device.py
+++ b/01OS/01OS/clients/base_device.py
@@ -1,6 +1,3 @@
-from dotenv import load_dotenv
-load_dotenv()  # take environment variables from .env.
-
 import os
 import asyncio
 import threading

--- a/01OS/01OS/server/i.py
+++ b/01OS/01OS/server/i.py
@@ -1,6 +1,3 @@
-from dotenv import load_dotenv
-load_dotenv()  # take environment variables from .env.
-
 import os
 import glob
 import time

--- a/01OS/01OS/server/llm.py
+++ b/01OS/01OS/server/llm.py
@@ -1,6 +1,3 @@
-from dotenv import load_dotenv
-load_dotenv()  # take environment variables from .env.
-
 import os
 import subprocess
 from pathlib import Path

--- a/01OS/01OS/server/server.py
+++ b/01OS/01OS/server/server.py
@@ -1,6 +1,3 @@
-from dotenv import load_dotenv
-load_dotenv()  # take environment variables from .env.
-
 import traceback
 from platformdirs import user_data_dir
 import ast

--- a/01OS/01OS/server/utils/kernel.py
+++ b/01OS/01OS/server/utils/kernel.py
@@ -1,6 +1,3 @@
-from dotenv import load_dotenv
-load_dotenv()  # take environment variables from .env.
-
 import asyncio
 import subprocess
 import platform

--- a/01OS/01OS/server/utils/logs.py
+++ b/01OS/01OS/server/utils/logs.py
@@ -1,6 +1,3 @@
-from dotenv import load_dotenv
-load_dotenv()  # take environment variables from .env.
-
 import os
 import logging
 


### PR DESCRIPTION
Call `load_dotenv()` once from `01OS/01OS/__init__.py` rather than multiple files.