### PR TITLE
Update to correct kernel.py url in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The 01 exposes a speech-to-speech websocket at `localhost:10001`.
 
 If you stream raw audio bytes to `/` in [LMC format](https://docs.openinterpreter.com/protocols/lmc-messages), you will receive its response in the same format.
 
-Inspired in part by [Andrej Karpathy's LLM OS](https://twitter.com/karpathy/status/1723140519554105733), we run a [code-interpreting language model](https://github.com/OpenInterpreter/open-interpreter), and call it when certain events occur at your computer's [kernel](https://github.com/OpenInterpreter/01/blob/main/01OS/01OS/server/utils/kernel.py).
+Inspired in part by [Andrej Karpathy's LLM OS](https://twitter.com/karpathy/status/1723140519554105733), we run a [code-interpreting language model](https://github.com/OpenInterpreter/open-interpreter), and call it when certain events occur at your computer's [kernel](https://github.com/OpenInterpreter/01/blob/main/software/source/server/utils/kernel.py).
 
 The 01 wraps this in a voice interface:
 


### PR DESCRIPTION
The main readme had the wrong URL for the kernel.py file.