### PR TITLE
Fix handling of empty audio content in listener function

### DIFF
--- a/software/source/server/server.py
+++ b/software/source/server/server.py
@@ -211,7 +211,7 @@ async def listener():
 
             if message["type"] == "audio" and message["format"].startswith("bytes"):
 
-                if "content" not in message or message["content"] == None: # If it was nothing / silence
+                if "content" not in message or message["content"] == None or message["content"] == "": # If it was nothing / silence / empty
                     continue
 
                 # Convert bytes to audio file


### PR DESCRIPTION
### Pull Request Description

Fixes #112

**Issue:**
There was an issue where the server would crash when trying to process an empty audio message. This was causing instability and interrupting the audio processing pipeline. (See screenshot below)

**Fix:**
This PR fixes the handling of empty audio content by skipping over messages that have an empty or missing "content" field. The `listener` function has been updated to check for this case and `continue` to the next message if the content is empty/missing.

Commit: `Fix handling of empty audio content in listener function (Fixes #112)`

Error screenshot
<img width="667" alt="error" src="https://github.com/OpenInterpreter/01/assets/77154365/b44af2c1-4352-43e9-8625-388e1ae2c9bd">

After changes
<img width="646" alt="After changes" src="https://github.com/OpenInterpreter/01/assets/77154365/7fd108e6-7677-41a6-aa6a-5d87ece554aa">

Changes:
<img width="1142" alt="Changes" src="https://github.com/OpenInterpreter/01/assets/77154365/acdc8c0d-ffb7-4c74-a52b-992fd3ebaf4a">

**Testing:**
I have tested this fix locally by sending empty audio messages to the server, and it no longer crashes. The server continues processing other messages as expected.

**Note:**
This change specifically addresses Issue #112, which was causing server instability when encountering empty audio content.

Please review the changes, and let me know if you have any further questions or concerns.
