### PR TITLE
Removed duplicate imports

### DIFF
--- a/software/source/server/server.py
+++ b/software/source/server/server.py
@@ -7,7 +7,6 @@ import ast
 import json
 import queue
 import os
-import traceback
 import datetime
 from .utils.bytes_to_wav import bytes_to_wav
 import re

--- a/software/source/server/services/tts/piper/tts.py
+++ b/software/source/server/services/tts/piper/tts.py
@@ -2,7 +2,6 @@ import ffmpeg
 import tempfile
 import os
 import subprocess
-import tempfile
 import urllib.request
 import tarfile
 


### PR DESCRIPTION
Fixed a couple instances of duplicate import statements:
- traceback imported twice in server.py
- tempfile imported twice in tts.py

First time contributing to OSS, so please let me know if anything is wrong with my PR. I chose something easy to get started.