### PR TITLE
Fix for Issue #104 - Add OPENAI_VOICE_NAME env variable

### DIFF
--- a/software/source/server/services/tts/openai/tts.py
+++ b/software/source/server/services/tts/openai/tts.py
@@ -14,7 +14,7 @@ class Tts:
     def tts(self, text):
             response = client.audio.speech.create(
                 model="tts-1",
-                voice="alloy",
+                voice=os.getenv('OPENAI_VOICE_NAME', 'alloy'),
                 input=text,
                 response_format="opus"
             )


### PR DESCRIPTION
This follows the way that Piper is implemented. OPENAI_VOICE_NAME env variable, with a default (alloy).

Fixes #104 .