### PR TITLE
Fix empty message array error when running on Windows

### DIFF
--- a/software/source/server/utils/kernel.py
+++ b/software/source/server/utils/kernel.py
@@ -45,15 +45,16 @@ last_messages = ""
 
 def check_filtered_kernel():
     messages = get_kernel_messages()
-    messages.replace(last_messages, "")
-    messages = messages.split("\n")
-    
-    filtered_messages = []
-    for message in messages:
-        if custom_filter(message):
-            filtered_messages.append(message)
-    
-    return "\n".join(filtered_messages)
+    if messages:
+        messages.replace(last_messages, "")
+        messages = messages.split("\n")
+        
+        filtered_messages = []
+        for message in messages:
+            if custom_filter(message):
+                filtered_messages.append(message)
+        
+        return "\n".join(filtered_messages)
 
 async def put_kernel_messages_into_queue(queue):
     while True:


### PR DESCRIPTION
The `messages` array is returned empty if the program runs on a platform apart from Linux or Darwin. This logic only processes the messages if the array is not empty. 