### PR TITLE
fix: unsupported escape sequence in string literal

### DIFF
--- a/software/source/clients/base_device.py
+++ b/software/source/clients/base_device.py
@@ -258,7 +258,7 @@ class Device:
                     if CAMERA_ENABLED:
                         print("\nHold the spacebar to start recording. Press 'c' to capture an image from the camera. Press CTRL-C to exit.")
                     else:
-                        print("\Hold the spacebar to start recording. Press CTRL-C to exit.")
+                        print("\nHold the spacebar to start recording. Press CTRL-C to exit.")
                         
                     asyncio.create_task(self.message_sender(websocket))
 


### PR DESCRIPTION
![image](https://github.com/OpenInterpreter/01/assets/52110451/48edd6ec-a352-4d3c-87ba-6183722562dc)
