### PR TITLE
Fix for Windows setup --server --local: TTS and STT

### DIFF
--- a/software/source/server/services/stt/local-whisper/stt.py
+++ b/software/source/server/services/stt/local-whisper/stt.py
@@ -42,8 +42,8 @@ def install(service_dir):
     # Check if whisper-rust executable exists before attempting to build
     if not os.path.isfile(os.path.join(WHISPER_RUST_PATH, "target/release/whisper-rust")):
         # Check if Rust is installed. Needed to build whisper executable
-        rust_check = subprocess.call('command -v rustc', shell=True)
-        if rust_check != 0:
+        rustc_path = shutil.which("rustc")
+        if rustc_path is None:
             print("Rust is not installed or is not in system PATH. Please install Rust before proceeding.")
             exit(1)
         

--- a/software/source/server/services/tts/piper/tts.py
+++ b/software/source/server/services/tts/piper/tts.py
@@ -49,7 +49,7 @@ class Tts:
                     return
             elif OS == "Windows":
                 if ARCH == "AMD64":
-                    ARCH = "x64"
+                    ARCH = "amd64"
                 else:
                     print("Piper: unsupported architecture")
                     return
@@ -57,14 +57,15 @@ class Tts:
             PIPER_ASSETNAME = f"piper_{OS}_{ARCH}.tar.gz"
             PIPER_URL = "https://github.com/rhasspy/piper/releases/latest/download/"
 
-            if OS == "windows":
-                asset_url = f"{PIPER_URL}{PIPER_ASSETNAME}".replace(".tar.gz", ".zip")
+            asset_url = f"{PIPER_URL}{PIPER_ASSETNAME}"
+            if OS == "Windows":
+                asset_url = asset_url.replace(".tar.gz", ".zip")
 
             # Download and extract Piper
             urllib.request.urlretrieve(asset_url, os.path.join(PIPER_FOLDER_PATH, PIPER_ASSETNAME))
 
             # Extract the downloaded file
-            if OS == "windows":
+            if OS == "Windows":
                 import zipfile
                 with zipfile.ZipFile(os.path.join(PIPER_FOLDER_PATH, PIPER_ASSETNAME), 'r') as zip_ref:
                     zip_ref.extractall(path=PIPER_FOLDER_PATH)

--- a/software/source/server/utils/kernel.py
+++ b/software/source/server/utils/kernel.py
@@ -45,6 +45,10 @@ last_messages = ""
 
 def check_filtered_kernel():
     messages = get_kernel_messages()
+    if messages is None:
+        return ""  # Handle unsupported platform or error in fetching kernel messages
+
+    global last_messages
     messages.replace(last_messages, "")
     messages = messages.split("\n")
     


### PR DESCRIPTION
Implemented fixes for:
- tts.py: Corrected Piper download link for Windows
- stt.py: Adjusted check for rust installation to also work with Windows
- kernel.py: Adjusted check_filtered_kernel() to not crash on empty messages