### PR TITLE
Fix UnboundLocalError for asset_url on Piper install (macOS)

### DIFF
--- a/software/source/server/services/tts/piper/tts.py
+++ b/software/source/server/services/tts/piper/tts.py
@@ -57,8 +57,10 @@ class Tts:
             PIPER_ASSETNAME = f"piper_{OS}_{ARCH}.tar.gz"
             PIPER_URL = "https://github.com/rhasspy/piper/releases/latest/download/"
 
+            asset_url = f"{PIPER_URL}{PIPER_ASSETNAME}"
+
             if OS == "windows":
-                asset_url = f"{PIPER_URL}{PIPER_ASSETNAME}".replace(".tar.gz", ".zip")
+                asset_url = asset_url.replace(".tar.gz", ".zip")
 
             # Download and extract Piper
             urllib.request.urlretrieve(asset_url, os.path.join(PIPER_FOLDER_PATH, PIPER_ASSETNAME))

--- a/software/source/server/services/tts/piper/tts.py
+++ b/software/source/server/services/tts/piper/tts.py
@@ -36,9 +36,9 @@ class Tts:
             os.makedirs(PIPER_FOLDER_PATH, exist_ok=True)
 
             # Determine OS and architecture
-            OS = platform.system()
+            OS = platform.system().lower()
             ARCH = platform.machine()
-            if OS == "Darwin":
+            if OS == "darwin":
                 OS = "macos"
                 if ARCH == "arm64":
                     ARCH = "aarch64"
@@ -47,7 +47,7 @@ class Tts:
                 else:
                     print("Piper: unsupported architecture")
                     return
-            elif OS == "Windows":
+            elif OS == "windows":
                 if ARCH == "AMD64":
                     ARCH = "x64"
                 else:


### PR DESCRIPTION
## Problem

Fixes the following error occurring when installing Piper TTS:

```
urllib.request.urlretrieve(asset_url, os.path.join(PIPER_FOLDER_PATH, PIPER_ASSETNAME))
UnboundLocalError: local variable 'asset_url' referenced before assignment
```

It constantly happens on macOS, preventing first run of the  `poetry run 01 --local` command.
It is seems to be happening on Windows as well (see https://github.com/OpenInterpreter/01/issues/167#issuecomment-2024628495). 

## Solution

Setting the `asset_url` variable before using it. 

## How To Test

1. Proceed with a first time install on macOS.
2. Run Ollama or LM Studio with a model in the background.
3. Run `poetry run 01 --local` from the `software` directory.

## Discussion 

Fix from #170 seemingly created a small regression by setting the value for `asset_url` in a Windows-only code-block.