### PR TITLE
basic support to build and upload the firmware from PlatformIO

### DIFF
--- a/hardware/light/README.md
+++ b/hardware/light/README.md
@@ -13,6 +13,22 @@ To set up audio recording + playback on the ESP32 (M5 Atom), do the following:
 
 Finally, to flash the .ino to the board, connect the board to the USB port, select the port from the dropdown on the IDE, then select the M5Atom board (or M5Stack-ATOM if you have that). Click on upload to flash the board.
 
+### Alternative - PlatformIO
+
+You don't need anything, PlatformIO will install everything for you, dependencies, tool chains, etc.
+
+Please install first [PlatformIO](http://platformio.org/) open source ecosystem for IoT development compatible with **Arduino** IDE and its command line tools (Windows, MacOs and Linux), and then enter to the firmware directory:
+
+```bash
+cd software/source/clients/esp32/src/client/
+``` 
+
+And build and upload the firmware with a simple command:
+
+```bash
+pio run --target upload
+``` 
+
 ## Wifi
 
 The board needs to connect to WiFi. Once you flash, connect to the ESP32 WiFi portal "01-Light" which will get WiFi details. Once it connects, it will ask you to enter 01OS server address. Once its able to connect, you can use the device.

--- a/software/source/clients/esp32/README.md
+++ b/software/source/clients/esp32/README.md
@@ -10,3 +10,20 @@ To set up audio recording + playback on the ESP32 (M5 Atom), do the following:
     - ESPAsyncWebServer by lacamera
 4. The board needs to connect to WiFi. Once you flash, connect to ESP32 wifi "captive" which will get wifi details. Once it connects, it will ask you to enter 01OS server address in the format "domain.com:port" or "ip:port". Once its able to connect you can use the device.
 5. To flash the .ino to the board, connect the board to the USB port, select the port from the dropdown on the IDE, then select the M5Atom board (or M5Stack-ATOM if you have that). Click on upload to flash the board.
+
+### Alternative - PlatformIO
+
+You don't need anything, PlatformIO will install everything for you, dependencies, tool chains, etc.
+
+Please install first [PlatformIO](http://platformio.org/) open source ecosystem for IoT development compatible with **Arduino** IDE and its command line tools (Windows, MacOs and Linux), and then enter to the firmware directory:
+
+```bash
+cd client/
+``` 
+
+And build and upload the firmware with a simple command:
+
+```bash
+pio run --target upload
+``` 
+

--- a/software/source/clients/esp32/src/client/platformio.ini
+++ b/software/source/clients/esp32/src/client/platformio.ini
@@ -1,0 +1,32 @@
+; ESPNowCam Freenove ESP32S3CAM
+; https://github.com/hpsaturn/esp32s3-cam
+; @Hpsaturn 2024
+
+[platformio]
+src_dir = ./
+
+[env]
+platform = espressif32
+framework = arduino
+monitor_speed = 115200
+upload_speed = 1500000
+monitor_filters = 
+  esp32_exception_decoder
+  time
+build_flags =
+  -D CORE_DEBUG_LEVEL=0
+  -D BOARD_HAS_PSRAM=1
+
+[esp32common]
+extends = env
+board = esp32dev
+
+[env:m5echo]
+extends = esp32common
+lib_deps = 
+  m5stack/M5Atom @ ^0.1.2
+  links2004/WebSockets @ ^2.4.1
+  ;esphome/ESPAsyncWebServer-esphome @ ^3.1.0
+  https://github.com/arduino-libraries/ArduinoHttpClient
+  https://github.com/lacamera/ESPAsyncWebServer
+  fastled/FastLED @ ^3.6.0


### PR DESCRIPTION
## Summary

In order to have a more easy and fastest builder and uploader of the current firmware, I wrote a small PlatformIO ini file to support it, and its documentation

- [x] platformio.ini manifest with dependencies, uploader and board specification
- [x] basic README sections on hardware and client directory
- [x] tested in real hardware M5Echo.
  