### PR TITLE
Shutdown gracefully if OpenAI key missing for default TTS

### DIFF
--- a/software/source/server/services/tts/openai/tts.py
+++ b/software/source/server/services/tts/openai/tts.py
@@ -5,6 +5,18 @@ import os
 import subprocess
 import tempfile
 
+from source.server.utils.logs import logger
+from source.server.utils.logs import setup_logging
+setup_logging()
+
+# If this TTS service is used, the OPENAI_API_KEY environment variable must be set
+if not os.getenv('OPENAI_API_KEY'):
+    logger.error("")
+    logger.error(f"OpenAI API key not found. Please set the OPENAI_API_KEY environment variable, or run 01 with the --local option.")
+    logger.error("Aborting...")
+    logger.error("")
+    os._exit(1)
+
 client = OpenAI()
 
 class Tts:


### PR DESCRIPTION
# Problem

When running `poetry run 01` with no option and without prior setting of the `OPENAI_API_KEY`, the application will throw an error (coming from the `openai.OpenAI` package). 

# Solution 

Defensive programming—verifying the presence of the key before invoking `openai.OpenAI`—to catch the issue and provide concise instruction on what to do instead of a scary stack trace.

# Tested On

- macOS
- Windows 10

# Discussion

No big deal, but this is a low-hanging fruit on removing onboarding friction. On Window (at least 10), given Ctrl+C doesn't seem to kill the process once the server started, it made the UX even more awkward.

**Before**

![Screenshot 2024-03-31 at 21 38 54](https://github.com/OpenInterpreter/01/assets/543614/de573b2a-66d3-435e-8181-01cd1647be1f)

**After**

![Screenshot 2024-03-31 at 21 39 07](https://github.com/OpenInterpreter/01/assets/543614/b797ad3a-a0eb-4d7d-b5d7-091a9ed38e5d)
