### PR TITLE
Update documentation for Windows installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ export OPENAI_API_KEY=sk... # OR run `poetry run 01 --local` to run everything l
 poetry run 01 # Runs the 01 Light simulator (hold your spacebar, speak, release)
 ```
 
+<!-- > For a Windows installation, read our [setup guide](https://docs.openinterpreter.com/getting-started/setup#windows). -->
+
 <br>
 
 # Hardware

--- a/docs/getting-started/introduction.mdx
+++ b/docs/getting-started/introduction.mdx
@@ -1,12 +1,12 @@
 ---
 title: Introduction
-description: "The open-source language model computer."
+description: 'The open-source language model computer.'
 ---
 
 <img
   src="https://www.openinterpreter.com/OI-O1-BannerDemo-3.jpg"
   alt="thumbnail"
-  style={{ transform: "translateY(-1.25rem)" }}
+  style={{ transform: 'translateY(-1.25rem)' }}
 />
 
 The 01 project is an open-source ecosystem for artificially intelligent devices.
@@ -26,6 +26,8 @@ brew install portaudio ffmpeg cmake
 # Ubuntu
 sudo apt-get install portaudio19-dev ffmpeg cmake
 ```
+
+For windows, please refer to the [setup guide](/getting-started/setup#windows).
 
 ### Install and run the 01 CLI
 

--- a/docs/getting-started/setup.mdx
+++ b/docs/getting-started/setup.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Setup"
-description: "Get your 01 up and running"
+title: 'Setup'
+description: 'Get your 01 up and running'
 ---
 
 ## Captive portal
@@ -25,6 +25,24 @@ brew install portaudio ffmpeg cmake
 
 # Ubuntu
 sudo apt-get install portaudio19-dev ffmpeg cmake
+
+# Install poetry
+curl -sSL https://install.python-poetry.org | python3 -
+```
+
+#### Windows
+
+On Windows you will need to install the following:
+
+- [Git for Windows](https://git-scm.com/download/win).
+- [virtualenv](https://virtualenv.pypa.io/en/latest/installation.html) or [MiniConda](https://docs.anaconda.com/free/miniconda/miniconda-install/) to manage virtual environments.
+- [Chocolatey](https://chocolatey.org/install#individual) to install the required packages.
+
+With these installed, you can run the following commands in a **PowerShell terminal as an administrator**:
+
+```powershell
+# Install the required packages
+choco install -y ffmpeg cmake
 ```
 
 ## Install 01
@@ -38,7 +56,7 @@ git clone https://github.com/OpenInterpreter/01.git
 
 ## Run the 01
 
-In order to run 01 on your computer, use [Poetry](https://python-poetry.org/docs/#installing-with-the-official-installer)
+In order to run 01 on your computer, use [Poetry](https://python-poetry.org/docs/#installing-with-the-official-installer).
 
 Navigate to the project's software directory:
 
@@ -64,8 +82,8 @@ You have the ability to set your <a href="/services/language-model">LLM</a>, <a 
 
 ## Server setup
 
-You are able to run just the <a href="/server/setup">server</a>
+You are able to run just the <a href="/server/setup">server</a>.
 
 ## Client setup
 
-You are able to run just the <a href="/client/setup">client</a>
+You are able to run just the <a href="/client/setup">client</a>.


### PR DESCRIPTION
# Problem

Installation for Windows, with its key differences, isn't provided in the documentation.

# Solution

Compile learnings from previous users' attempt (including [Zorcon's on Discord](https://discord.com/channels/1146610656779440188/1194880263122075688/1222294640867414097) and my own on Windows 10). Update the documentation in a concise and clear way.

**Introduction**

![Screenshot 2024-03-31 at 22 06 09](https://github.com/OpenInterpreter/01/assets/543614/ebd2519d-bebd-417e-825d-a1d626a6e915)

**Setup**

![Screenshot 2024-03-31 at 22 06 36](https://github.com/OpenInterpreter/01/assets/543614/bf534672-6fab-4745-90c4-c007cf9c7240)

# Tested On

- macOS
- Windows 10

# Discussion

To keep information as concise and truthful as possible, I have re-done a full install from scratch in another directory on a Win (10) machine. This prevents piling up command and dependencies install on top of each other, ensuring each step is meticulously found as necessary. While this is not fool-proof (and Windows isn't my platform of choice) it sure narrows down to the essence.

You'll see that `portaudio` is not listed as a dependency to install via the `choco` dependency manager. This is because unlike on other platform's dep manager, it [cannot be installed via Chocolatey](https://github.com/PortAudio/portaudio/issues/578). Luckily it [seems to be installed by the (already present) `pyaudio` dependency](https://stackoverflow.com/questions/51992375/how-to-fix-installation-issues-for-pyaudio-portaudio-fatal-error-c1083-canno).