### PR TITLE
Ubuntu 21+ wayland is not supported by some dependencies

### DIFF
--- a/docs/getting-started/setup.mdx
+++ b/docs/getting-started/setup.mdx
@@ -23,7 +23,7 @@ There are a few packages that need to be installed in order to run 01OS on your 
 # MacOS
 brew install portaudio ffmpeg cmake
 
-# Ubuntu
+# Ubuntu (wayland not supported, only ubuntu 20.04 and below)
 sudo apt-get install portaudio19-dev ffmpeg cmake
 
 # Install poetry


### PR DESCRIPTION
Updating docs to reflect this
pyautogui, pywinctl https://github.com/OpenInterpreter/01/blob/main/software/source/server/i.py#L218
![image](https://github.com/OpenInterpreter/01/assets/4324290/cd9c4741-e0fc-4f78-b5f8-a78bebee5647)
