### PR TITLE
Resolving the Disconnect Message

### DIFF
--- a/software/source/clients/base_device.py
+++ b/software/source/clients/base_device.py
@@ -355,7 +355,7 @@ class Device:
         else:
             while True:
                 try:
-                    async with websockets.connect(WS_URL) as websocket:
+                    async with websockets.connect(WS_URL, ping_timeout=None) as websocket:
                         await exec_ws_communication(websocket)
                 except:
                     logger.debug(traceback.format_exc())


### PR DESCRIPTION
This resolves #127. The 01OS will print the "Cannot call "receive" once a disconnect message has been received." message because the ping of the `websockets.connect` call does not set the `ping_timeout` to `None`; its default is 20 seconds. Slower computers running locally will receive this quite a bit.

Tested on:
Debian 11 (aarch64)
Python 3.11.19