### PR TITLE
Add library ESPAsyncWebServer to ESP setup README

### DIFF
--- a/hardware/light/README.md
+++ b/hardware/light/README.md
@@ -11,6 +11,7 @@ To set up audio recording + playback on the ESP32 (M5 Atom), do the following:
 - M5Atom by M5Stack [Reference](https://www.arduino.cc/reference/en/libraries/m5atom/)
 - WebSockets by Markus Sattler [Reference](https://www.arduino.cc/reference/en/libraries/websockets/)
 - AsyncTCP by dvarrel [Reference](https://github.com/dvarrel/AsyncTCP)
+- ESPAsyncWebServer by lacamera [Reference](https://github.com/me-no-dev/ESPAsyncWebServer)
 
 Finally, to flash the .ino to the board, connect the board to the USB port, select the port from the dropdown on the IDE, then select the M5Atom board (or M5Stack-ATOM if you have that). Click on upload to flash the board.
 


### PR DESCRIPTION
Got a `"ESPAsyncWebServer.h: No such file or directory"` error without installing ESPAsyncWebServer

Got it working after installing this via the Library manager, is that the right fix here?